### PR TITLE
Export parseBoundary

### DIFF
--- a/upload.go
+++ b/upload.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"google.golang.org/grpc/metadata"
 )
 
@@ -118,8 +119,9 @@ func parseMultipartForm(server uploadServer, sizeLimit int64) (*multipart.Form, 
 	return reader.ReadForm(maxMemory)
 }
 
+// ParseBoundary parses the boundary parameter from the given metadata.
 func ParseBoundary(md metadata.MD) (string, error) {
-	contentType := pick(md, "grpcgateway-content-type")
+	contentType := pick(md, fmt.Sprintf("%s%s", runtime.MetadataPrefix, "content-type"))
 	if contentType == "" {
 		return "", http.ErrNotMultipart
 	}

--- a/upload.go
+++ b/upload.go
@@ -109,7 +109,7 @@ func (f *FormData) FirstValue(key string) string {
 
 func parseMultipartForm(server uploadServer, sizeLimit int64) (*multipart.Form, error) {
 	md, _ := metadata.FromIncomingContext(server.Context())
-	boundary, err := parseBoundary(md)
+	boundary, err := ParseBoundary(md)
 	if err != nil {
 		return nil, err
 	}
@@ -118,7 +118,7 @@ func parseMultipartForm(server uploadServer, sizeLimit int64) (*multipart.Form, 
 	return reader.ReadForm(maxMemory)
 }
 
-func parseBoundary(md metadata.MD) (string, error) {
+func ParseBoundary(md metadata.MD) (string, error) {
 	contentType := pick(md, "grpcgateway-content-type")
 	if contentType == "" {
 		return "", http.ErrNotMultipart


### PR DESCRIPTION
In some cases I need to use parseBoundary to handle grpcgateway-content-type