### PR TITLE
Add `RemoveAll` method to `FormData` to prevent temporary file buildup

### DIFF
--- a/examples/service.go
+++ b/examples/service.go
@@ -38,6 +38,8 @@ func (*Service) UploadFile(server proto.Service_UploadFileServer) error {
 
 		return status.Errorf(codes.Internal, err.Error())
 	}
+	// Clean up all temporary form data files after processing completes.
+	defer formData.RemoveAll()
 
 	fileHeader := formData.FirstFile("key1")
 	if fileHeader == nil {
@@ -64,6 +66,8 @@ func (*Service) UploadMultipleFiles(server proto.Service_UploadMultipleFilesServ
 
 		return status.Errorf(codes.Internal, err.Error())
 	}
+	// Clean up all temporary form data files after processing completes.
+	defer formData.RemoveAll()
 
 	// one file for one key
 	firstFileHeader := formData.FirstFile("key1")

--- a/upload.go
+++ b/upload.go
@@ -108,6 +108,11 @@ func (f *FormData) FirstValue(key string) string {
 	return values[0]
 }
 
+// RemoveAll removes any temporary files associated with a from data
+func (f *FormData) RemoveAll() error {
+	return f.form.RemoveAll()
+}
+
 // ProcessMultipartUpload processes the provided multipart upload. The provided function is called for each part.
 // sizeLimit is the maximum size of the form data in bytes (0 = unlimited).
 // Useful for forwarding multipart requests to another server without saving them locally or in memory.


### PR DESCRIPTION
Hello @black-06, here is an MR that fixes one issue I've encountered working with grpc-gateway-file.

## Description

This PR introduces a method, `RemoveAll`, within the `FormData` struct to clean up temporary files after data processing is completed. The previous implementation did not properly handle file removal, which led to a build-up of temporary files and eventually caused an "out of storage" issue.

## Changes

- **Added `RemoveAll` function** in the `FormData` struct to explicitly remove all temporary form data files.
- **Added `defer formData.RemoveAll()`** to examples to ensure that temporary files are cleaned up once processing completes.

## Context
The library did not allow for cleanup of temporary files, causing storage issues over time due to residual data. This update addresses that issue by enabling proper cleanup. For additional context, refer to [golang/go#20253](https://github.com/golang/go/issues/20253) and https://pkg.go.dev/mime/multipart#Reader.ReadForm.

## Additional Notes

This change is essential for environments where storage resources are limited, as it prevents storage from filling up due to temporary file buildup.